### PR TITLE
failing unit tests on devnet fixed

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -1,13 +1,13 @@
 [features]
 seeds = false
-[programs.localnet]
-solanaloans = "Em8pj36RxaefZ2cm9ZfcnyXedyemqbDVgTbGGcQMae5A"
+[programs.devnet]
+solanaloans = "BBZ2HBi6WbaFtGeXwewBbMe3x4foTcrQNfc4jJUPLt8a"
 
 [registry]
 url = "https://anchor.projectserum.com"
 
 [provider]
-cluster = "localnet"
+cluster = "devnet"
 wallet = "/Users/lukeqin/.config/solana/id.json"
 
 [scripts]

--- a/programs/solanaloans/src/lib.rs
+++ b/programs/solanaloans/src/lib.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::entrypoint::ProgramResult;
 use anchor_lang::solana_program::sysvar::clock::Clock;
 
-declare_id!("Em8pj36RxaefZ2cm9ZfcnyXedyemqbDVgTbGGcQMae5A");
+declare_id!("BBZ2HBi6WbaFtGeXwewBbMe3x4foTcrQNfc4jJUPLt8a");
 
 #[program]
 pub mod solanaloans {
@@ -10,9 +10,9 @@ pub mod solanaloans {
   pub fn initialize(ctx: Context<Initialize>) -> ProgramResult {
     let base_account = &mut ctx.accounts.base_account;
     let lamports_per_sol = 1000000000;
-    base_account.minimum_balance = 2 * lamports_per_sol;
-    base_account.loan_amount = 2 * lamports_per_sol;
-    base_account.loan_repayment_amount = 3 * lamports_per_sol;
+    base_account.loan_amount = lamports_per_sol / 2;
+    base_account.minimum_balance = base_account.loan_amount;
+    base_account.loan_repayment_amount = 2 * lamports_per_sol;
     base_account.default_loan_struct = LoanStruct {
       amount: 0,
       is_paid: true,

--- a/tests/solanaloans.js
+++ b/tests/solanaloans.js
@@ -7,45 +7,9 @@ describe("solanaloans", () => {
   const provider = anchor.Provider.env();
   anchor.setProvider(provider);
 
-  it("Initializes and creates a loan for a user.", async () => {
-    const LAMPORTS_PER_SOL = 1000000000;
-    const SOL_AMOUNT = 10;
-    const NUM_LAMPORTS = SOL_AMOUNT * LAMPORTS_PER_SOL;
-
-    const program = anchor.workspace.Solanaloans;
-    const baseAccount = anchor.web3.Keypair.generate();
-
-    await provider.connection.confirmTransaction(
-      await provider.connection.requestAirdrop(
-        baseAccount.publicKey,
-        NUM_LAMPORTS
-      ),
-      "confirmed"
-    );
-
-    await program.rpc.initialize({
-      accounts: {
-        baseAccount: baseAccount.publicKey,
-        user: provider.wallet.publicKey,
-        systemProgram: SystemProgram.programId,
-      },
-      signers: [baseAccount],
-    });
-    await program.rpc.createLoan({
-      accounts: {
-        baseAccount: baseAccount.publicKey,
-        user: provider.wallet.publicKey,
-        systemProgram: SystemProgram.programId,
-      },
-    });
-    const programBalance = await program.account.baseAccount.getAccountInfo(
-      baseAccount.publicKey
-    );
-    expect(programBalance.lamports.toString()).equal("8000000000");
-  });
   it("Initializes, creates a loan for a user, and enables them to pay the loan back.", async () => {
     const LAMPORTS_PER_SOL = 1000000000;
-    const SOL_AMOUNT = 10;
+    const SOL_AMOUNT = 0.75;
     const NUM_LAMPORTS = SOL_AMOUNT * LAMPORTS_PER_SOL;
 
     const program = anchor.workspace.Solanaloans;
@@ -84,6 +48,6 @@ describe("solanaloans", () => {
     const programBalance = await program.account.baseAccount.getAccountInfo(
       baseAccount.publicKey
     );
-    expect(programBalance.lamports.toString()).equal("11000000000");
+    expect(programBalance.lamports.toString()).equal("2250000000");
   });
 });


### PR DESCRIPTION
Previously, running `anchor test` on devnet would result in the following error output despite the passing tests of the same command on `localhost`

```
Transaction simulation failed: Error processing Instruction 0: insufficient funds for instruction 
    Program BBZ2HBi6WbaFtGeXwewBbMe3x4foTcrQNfc4jJUPLt8a invoke [1]
    Program log: Instruction: CreateLoan
    Program log: ProgramError occurred. Error Code: InsufficientFunds. Error Number: 25769803776. Error Message: An account's balance was too small to complete the instruction.
    Program BBZ2HBi6WbaFtGeXwewBbMe3x4foTcrQNfc4jJUPLt8a consumed 6452 of 200000 compute units
    Program BBZ2HBi6WbaFtGeXwewBbMe3x4foTcrQNfc4jJUPLt8a failed: insufficient funds for instruction
    1) Initializes and creates a loan for a user.
Server responded with 429 Too Many Requests.  Retrying after 500ms delay...
Server responded with 429 Too Many Requests.  Retrying after 1000ms delay...
Server responded with 429 Too Many Requests.  Retrying after 2000ms delay...
Server responded with 429 Too Many Requests.  Retrying after 4000ms delay...
    2) Initializes, creates a loan for a user, and enables them to pay the loan back.


  0 passing (13s)
  2 failing

  1) solanaloans
       Initializes and creates a loan for a user.:
     Error: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: insufficient funds for instruction
      at Connection.sendEncodedTransaction (node_modules/@solana/web3.js/lib/index.cjs.js:6817:13)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      at async Connection.sendRawTransaction (node_modules/@solana/web3.js/lib/index.cjs.js:6772:20)
      at async sendAndConfirmRawTransaction (node_modules/@solana/web3.js/lib/index.cjs.js:9133:21)
      at async Provider.send (node_modules/@project-serum/anchor/dist/cjs/provider.js:90:22)
      at async Object.rpc [as createLoan] (node_modules/@project-serum/anchor/dist/cjs/program/namespace/rpc.js:31:31)
      at async Context.<anonymous> (tests/solanaloans.js:34:5)

  2) solanaloans
       Initializes, creates a loan for a user, and enables them to pay the loan back.:
     Error: 429 Too Many Requests:  {"jsonrpc":"2.0","error":{"code": 429, "message":"Too many requests for a specific RPC call, contact your app developer or support@rpcpool.com."}, "id": "d95debf7-dd3d-4252-8781-3f21b15e5424" } 

      at ClientBrowser.callServer (node_modules/@solana/web3.js/lib/index.cjs.js:4438:18)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
```
The reason why there were insufficient funds for the transaction was because the `createLoan()` function was failing in both tests because of this check:
```
    // Return an error if the account does not have a sufficient balance to make a loan.
    if *lamports < minimum_balance {
      return Err(ProgramError::InsufficientFunds);
    }
```
This should not have been happening because the unit tests airdrop SOL to the program before running any functions. However, console logging the outputs revealed these airdrops were not going through. For the first unit test, the airdrop did not go through because the airdrop request size was too large (>2 SOL). For the second unit test, the airdrop most likely did not go through because the provider had most recently made an airdrop request so it was being rate limited.

This fix removes a unit test so that there is only one airdrop request and makes sure that the request size is less than 2 SOL.
